### PR TITLE
Memberlist headlines aligned with "individual" fields

### DIFF
--- a/contrib/phpbb-3.1.6-pre/modified/phpbb/profilefields/manager.php
+++ b/contrib/phpbb-3.1.6-pre/modified/phpbb/profilefields/manager.php
@@ -292,11 +292,25 @@ class manager
 			$profile_field = $this->type_collection[$field_data['field_type']];
 
 			$tpl_fields[] = array(
+				'PROFILE_FIELD_IDENT'	=> $field_ident,
 				'PROFILE_FIELD_TYPE'	=> $field_data['field_type'],
 				'PROFILE_FIELD_NAME'	=> $profile_field->get_field_name($field_data['lang_name']),
 				'PROFILE_FIELD_EXPLAIN'	=> $this->user->lang($field_data['lang_explain']),
 			);
 		}
+
+		$profile_cache = $this->profile_cache;
+		/**
+		* Event to modify template headlines of the generated profile fields
+		*
+		* @event core.generate_profile_fields_template_headlines
+		* @var	string	restrict_option	Restrict the published fields to a certain profile field option
+		* @var	array	tpl_fields		Array with template data fields
+		* @var	array	profile_cache	A copy of the profile cache to make additional checks
+		* @since 3.1.6-RC1
+		*/
+		$vars = array('restrict_option', 'tpl_fields', 'profile_cache');
+		extract($this->dispatcher->trigger_event('core.generate_profile_fields_template_headlines', compact($vars)));
 
 		return $tpl_fields;
 	}

--- a/contrib/phpbb-3.1.6-pre/readme.txt
+++ b/contrib/phpbb-3.1.6-pre/readme.txt
@@ -12,6 +12,7 @@ The list of modifications included here is the following:
 [*][url=https://github.com/phpbb/phpbb/pull/3733][ticket/13934] Add enctype clause for profile fields[/url]
 [*][url=https://github.com/phpbb/phpbb/pull/3724][ticket/13960] Profile field validation breaks ACP[/url]
 [*][url=https://github.com/phpbb/phpbb/pull/3739][ticket/13982] Add events around ranks[/url]
+[*][url=https://github.com/phpbb/phpbb/pull/3779][ticket/14037] Allows adapting memberlist profile fields headline[/url]
 
 To install, copy the CONTENTS of the "modified" folder to the root of your forum, overwritting the existing files.
 For your convenience, I have included here a fresh copy of the standard 3.1.5 files in the "phpbb-3.1.5" folder.

--- a/event/listener.php
+++ b/event/listener.php
@@ -60,6 +60,7 @@ class listener implements EventSubscriberInterface
 	{
 		return array(
 			'core.generate_profile_fields_template_data'	=> 'remove_individual_fields_from_block',
+			'core.generate_profile_fields_template_headlines'	=> 'remove_individual_fields_from_headlines',
 			'core.acp_profile_create_edit_init'				=> 'manage_additional_column_in_profilefields_init',
 			'core.acp_profile_create_edit_after'			=> 'manage_additional_column_in_profilefields_after',
 			'core.acp_profile_create_edit_before_save'		=> 'manage_additional_column_in_profilefields_save',
@@ -92,6 +93,31 @@ class listener implements EventSubscriberInterface
 		$tpl_fields['blockrow'] = $new_blockrow;
 
 		$event['tpl_fields'] = $tpl_fields;
+	}
+
+	/**
+	 * Removes profile fields classified as individual from profile fields headlines
+	 *
+	 * @param object $event The event object
+	 * @return void
+	 */
+	public function remove_individual_fields_from_headlines($event)
+	{
+		$profile_cache = $event['profile_cache'];
+		$tpl_fields = $event['tpl_fields'];
+
+		$new_tpl_fields = array();
+		foreach ($tpl_fields as $field_block)
+		{
+			$ident = $field_block['PROFILE_FIELD_IDENT'];
+			if ($profile_cache[$ident]['field_individual'])
+			{
+				continue;
+			}
+			$new_tpl_fields[] = $field_block;
+		}
+
+		$event['tpl_fields'] = $new_tpl_fields;
 	}
 
 	/**


### PR DESCRIPTION
Use the new core event to modify the memberlist pf headlines to remove fields that are marked as "individual".  Additional core event for memberlist pf headline (ticket 14037).

Issue #1
