### PR TITLE
Use default value as "no_value" when required

### DIFF
--- a/profilefields/type/type_img_base.php
+++ b/profilefields/type/type_img_base.php
@@ -378,6 +378,10 @@ abstract class type_img_base extends \phpbb\profilefields\type\type_base
 
 			return $current_value;
 		}
+		if ($step == 2 && $key == 'field_novalue' && $this->request->is_set('field_default_value'))
+		{
+			return utf8_normalize_nfc(request_var('field_default_value', '', true));
+		}
 
 		return parent::get_excluded_options($key, $action, $current_value, $field_data, $step);
 	}


### PR DESCRIPTION
This applies to all image profile fields.

Issue #2
